### PR TITLE
Add test for SentimentSlider

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect']
+};

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "tsc",
     "prepare": "npm run build",
-    "test": "echo \"No tests implemented yet\""
+    "test": "jest"
   },
   "keywords": [
     "react",
@@ -40,6 +40,11 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "jest": "^29.5.0",
+    "ts-jest": "^29.0.5",
+    "@types/jest": "^29.5.0",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/src/SentimentSlider.test.tsx
+++ b/src/SentimentSlider.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SentimentSlider from './SentimentSlider';
+
+it('calls onConfirm with the slider value after sliding and confirming', () => {
+  jest.useFakeTimers();
+  const onConfirm = jest.fn();
+  render(<SentimentSlider onConfirm={onConfirm} />);
+
+  const slider = screen.getByRole('slider');
+
+  fireEvent.mouseDown(slider);
+  fireEvent.change(slider, { target: { value: '80' } });
+  fireEvent.mouseUp(slider);
+
+  jest.advanceTimersByTime(501);
+
+  const button = screen.getByRole('button', { name: /next question/i });
+  fireEvent.click(button);
+
+  expect(onConfirm).toHaveBeenCalledWith(80);
+  jest.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- add basic jest configuration
- add test for SentimentSlider using React Testing Library
- update `package.json` test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846b8dfef348331b915c73c49adf99a