### PR TITLE
Fix slider reset when initialValue changes

### DIFF
--- a/examples/SentimentSliderExample.tsx
+++ b/examples/SentimentSliderExample.tsx
@@ -77,11 +77,13 @@ export default function FeedbackSurvey() {
           </div>
           
           <SentimentSlider
+            key={questions[currentQuestionIndex].id}
             questionText={questions[currentQuestionIndex].question}
             onConfirm={handleSentimentConfirm}
+            initialValue={50}
             nextButtonText={
-              currentQuestionIndex < questions.length - 1 
-                ? "Next question" 
+              currentQuestionIndex < questions.length - 1
+                ? "Next question"
                 : "Complete survey"
             }
           />

--- a/src/SentimentSlider.tsx
+++ b/src/SentimentSlider.tsx
@@ -55,6 +55,11 @@ export function SentimentSlider({
   const sliderRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Update slider value if initialValue prop changes
+  useEffect(() => {
+    setSliderValue(initialValue);
+  }, [initialValue]);
+
   // Get feedback text based on slider value
   const getSentimentText = (value: number): string => {
     if (value < 20) return "Negative";


### PR DESCRIPTION
## Summary
- keep SentimentSlider value in sync with initialValue prop
- reset slider between questions in example survey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b6c81f4c833196a506b781779d0b