### PR TITLE
Add SentimentSliderSpectacular variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,17 @@ function FeedbackForm() {
 }
 
 export default FeedbackForm;
+## Spectacular Variant
+
+For more dramatic visuals you can import the **SentimentSliderSpectacular** component:
+
+```jsx
+import { SentimentSliderSpectacular } from "sentiment-slider";
+import "sentiment-slider/dist/SentimentSliderSpectacular.css";
+
+<SentimentSliderSpectacular onConfirm={handleConfirm} />
 ```
+
 
 ## Props
 

--- a/docs/SentimentSlider.md
+++ b/docs/SentimentSlider.md
@@ -90,6 +90,14 @@ function CustomerFeedbackForm() {
   );
 }
 ```
+### Spectacular Variant
+For a more vibrant look, use `SentimentSliderSpectacular`:
+```tsx
+import { SentimentSliderSpectacular } from "../src/SentimentSliderSpectacular";
+
+<SentimentSliderSpectacular onConfirm={handleNextQuestion} />
+```
+
 
 ## Customization API
 

--- a/src/SentimentSliderSpectacular.css
+++ b/src/SentimentSliderSpectacular.css
@@ -1,0 +1,244 @@
+/* SentimentSliderSpectacular.css */
+
+.sentiment-slider-container {
+  width: 100%;
+  max-width: 500px;
+  min-height: 300px;
+  border-radius: 16px;
+  padding: 20px;
+  margin: 0 auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition: background-color 0.25s ease-in-out;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+}
+
+.sentiment-content {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 30px;
+}
+
+.sentiment-question {
+  color: white;
+  text-align: center;
+  margin: 0;
+  font-size: 24px;
+  font-weight: 500;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.slider-container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+}
+
+.sentiment-text {
+  font-size: 24px;
+  font-weight: 500;
+  color: white;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+}
+
+.slider-wrapper {
+  width: 100%;
+  position: relative;
+  height: 40px;
+  display: flex;
+  align-items: center;
+}
+
+.sentiment-slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  outline: none;
+  position: relative;
+  z-index: 2;
+}
+
+.sentiment-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: white;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: all 0.1s ease;
+}
+
+.sentiment-slider::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: white;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  transition: all 0.1s ease;
+  border: none;
+}
+
+.sentiment-slider:active::-webkit-slider-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sentiment-slider:active::-moz-range-thumb {
+  transform: scale(1.2);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sentiment-labels {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  margin-top: -10px;
+}
+
+.sentiment-label-negative,
+.sentiment-label-positive {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.9);
+  font-weight: 500;
+}
+
+.sentiment-instruction {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-top: 5px;
+  font-style: italic;
+}
+
+.ripple {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  background-color: rgba(255, 255, 255, 0.8);
+  border-radius: 50%;
+  animation: ripple-effect 0.6s ease-out;
+  z-index: 1;
+  pointer-events: none;
+}
+.ripple-primary {
+  width: 60px;
+  height: 60px;
+}
+
+.ripple-secondary {
+  width: 80px;
+  height: 80px;
+  animation: ripple-effect-secondary 0.8s ease-out;
+}
+@keyframes ripple-effect {
+  0% {
+    transform: translateY(-50%) scale(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-50%) scale(2.5);
+    opacity: 0;
+  }
+}
+
+@keyframes ripple-effect-secondary {
+  0% {
+    transform: translateY(-50%) scale(0);
+    opacity: 0.6;
+  }
+  100% {
+    transform: translateY(-50%) scale(3);
+    opacity: 0;
+  }
+}
+
+
+.confirm-button {
+  background-color: white;
+  color: #333;
+  border: none;
+  border-radius: 50px;
+  padding: 12px 24px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  opacity: 0;
+  transform: translateY(10px);
+  margin-top: 10px;
+}
+
+.confirm-button:hover {
+  background-color: #f8f8f8;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+}
+
+.confirm-button:active {
+  transform: translateY(2px) scale(0.98);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.confirm-button.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Special class to prevent body scrolling while sliding */
+body.no-scroll {
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+  height: 100%;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+
+  .sentiment-slider-container {
+    border-radius: 12px;
+    min-height: 250px;
+  }
+
+  .sentiment-question {
+    font-size: 20px;
+  }
+
+  .sentiment-text {
+    font-size: 20px;
+  }
+
+  .confirm-button {
+    padding: 10px 20px;
+    font-size: 14px;
+  }
+
+  .ripple-primary {
+    width: 50px;
+    height: 50px;
+  }
+
+  .ripple-secondary {
+    width: 70px;
+    height: 70px;
+  }
+}

--- a/src/SentimentSliderSpectacular.test.tsx
+++ b/src/SentimentSliderSpectacular.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SentimentSliderSpectacular from './SentimentSliderSpectacular';
+
+it('calls onConfirm with the slider value after sliding and confirming', () => {
+  jest.useFakeTimers();
+  const onConfirm = jest.fn();
+  render(<SentimentSliderSpectacular onConfirm={onConfirm} />);
+
+  const slider = screen.getByRole('slider');
+
+  fireEvent.mouseDown(slider);
+  fireEvent.change(slider, { target: { value: '80' } });
+  fireEvent.mouseUp(slider);
+
+  jest.advanceTimersByTime(501);
+
+  const button = screen.getByRole('button', { name: /next question/i });
+  fireEvent.click(button);
+
+  expect(onConfirm).toHaveBeenCalledWith(80);
+  jest.useRealTimers();
+});

--- a/src/SentimentSliderSpectacular.tsx
+++ b/src/SentimentSliderSpectacular.tsx
@@ -1,0 +1,219 @@
+import React, { useEffect, useRef, useState } from 'react';
+import './SentimentSliderSpectacular.css';
+
+/**
+ * SentimentSlider Props Interface
+ */
+export interface SentimentSliderSpectacularProps {
+  /**
+   * Initial value for the slider (0-100)
+   * Default: 50 (neutral position)
+   */
+  initialValue?: number;
+  
+  /**
+   * Callback function triggered when user confirms their selection
+   */
+  onConfirm: (value: number) => void;
+  
+  /**
+   * Optional custom question text
+   * Default: "How do you feel?"
+   */
+  questionText?: string;
+  
+  /**
+   * Optional custom next button text
+   * Default: "Next question"
+   */
+  nextButtonText?: string;
+  
+  /**
+   * Optional class name for additional styling
+   */
+  className?: string;
+}
+
+/**
+ * SentimentSlider Component
+ * 
+ * A touch-friendly sentiment slider with dynamic colors and animations.
+ * Version 2.0 - Text-based feedback (no emojis)
+ */
+export function SentimentSliderSpectacular({
+  initialValue = 50,
+  onConfirm,
+  questionText = "How do you feel?",
+  nextButtonText = "Next question",
+  className = ""
+}: SentimentSliderSpectacularProps) {
+  const [sliderValue, setSliderValue] = useState(initialValue);
+  const [isSliding, setIsSliding] = useState(false);
+  const [showRipple, setShowRipple] = useState(false);
+  const [ripplePosition, setRipplePosition] = useState(50);
+  const [showConfirmButton, setShowConfirmButton] = useState(false);
+  const sliderRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Update slider value if initialValue prop changes
+  useEffect(() => {
+    setSliderValue(initialValue);
+  }, [initialValue]);
+
+  // Get feedback text based on slider value
+  const getSentimentText = (value: number): string => {
+    if (value < 20) return "Negative";
+    if (value < 40) return "Somewhat Negative";
+    if (value < 48) return "Slightly Negative";
+    if (value > 80) return "Positive";
+    if (value > 60) return "Somewhat Positive";
+    if (value > 52) return "Slightly Positive";
+    return "Neutral";
+  };
+
+  // Get background color based on slider value
+  const getBackground = (value: number): string => {
+    const hue = (value / 100) * 120;
+    const nextHue = Math.min(120, hue + 20);
+    return `linear-gradient(90deg, hsl(${hue},85%,50%), hsl(${nextHue},85%,50%))`;
+  };
+
+  // Prevent scrolling while using slider
+  useEffect(() => {
+    const preventTouchScroll = (e: TouchEvent) => {
+      if (isSliding) {
+        e.preventDefault();
+      }
+    };
+
+    const preventWheelScroll = (e: WheelEvent) => {
+      if (isSliding) {
+        e.preventDefault();
+      }
+    };
+
+    const preventElasticScroll = (e: TouchEvent) => {
+      if (isSliding && e.touches[0] && 
+          (e.touches[0].clientY < 10 || 
+           e.touches[0].clientY > window.innerHeight - 10)) {
+        e.preventDefault();
+      }
+    };
+
+    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+    document.addEventListener('wheel', preventWheelScroll, { passive: false });
+    document.addEventListener('touchstart', preventElasticScroll, { passive: false });
+
+    // Use no-scroll class to prevent scrolling
+    if (isSliding) {
+      document.body.classList.add('no-scroll');
+    } else {
+      document.body.classList.remove('no-scroll');
+    }
+
+    return () => {
+      document.removeEventListener('touchmove', preventTouchScroll);
+      document.removeEventListener('wheel', preventWheelScroll);
+      document.removeEventListener('touchstart', preventElasticScroll);
+      document.body.classList.remove('no-scroll');
+    };
+  }, [isSliding]);
+
+  // Handle slider change
+  const handleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = parseInt(event.target.value, 10);
+    setSliderValue(newValue);
+  };
+
+  // Handle slide start
+  const handleSlideStart = () => {
+    setIsSliding(true);
+    setShowRipple(false);
+    setShowConfirmButton(false);
+  };
+
+  // Handle slide end
+  const handleSlideEnd = () => {
+    setIsSliding(false);
+    setRipplePosition(sliderValue);
+    setShowRipple(true);
+    
+    // Show confirmation button after interaction
+    setTimeout(() => {
+      setShowConfirmButton(true);
+    }, 500);
+    
+    // Reset ripple after animation
+    setTimeout(() => {
+      setShowRipple(false);
+    }, 600);
+  };
+
+  // Handle confirmation
+  const handleConfirm = () => {
+    if (onConfirm) {
+      onConfirm(sliderValue);
+    }
+  };
+
+  const background = getBackground(sliderValue);
+  const sentimentText = getSentimentText(sliderValue);
+
+  return (
+    <div 
+      className={`sentiment-slider-container ${className}`} 
+      style={{ background }}
+      ref={containerRef}
+    >
+      <div className="sentiment-content">
+        <h2 className="sentiment-question">{questionText}</h2>
+        
+        <div className="slider-container">
+          <div className="sentiment-text">{sentimentText}</div>
+          
+          <div className="slider-wrapper">
+            <input
+              ref={sliderRef}
+              type="range"
+              min="0"
+              max="100"
+              value={sliderValue}
+              onChange={handleSliderChange}
+              onMouseDown={handleSlideStart}
+              onTouchStart={handleSlideStart}
+              onMouseUp={handleSlideEnd}
+              onTouchEnd={handleSlideEnd}
+              className="sentiment-slider"
+            />
+            
+            {showRipple && (
+              <div 
+                className="ripple ripple-primary" 
+                style={{ left: `${ripplePosition}%` }}
+              ></div>
+              <div className="ripple ripple-secondary" style={{ left: `${ripplePosition}%` }}></div>
+            )}
+          </div>
+          
+          <div className="sentiment-labels">
+            <span className="sentiment-label-negative">Negative</span>
+            <span className="sentiment-label-positive">Positive</span>
+          </div>
+          
+          <div className="sentiment-instruction">
+            Slide to indicate your sentiment
+          </div>
+        </div>
+        
+        <button 
+          onClick={handleConfirm}
+          className={`confirm-button ${showConfirmButton ? 'visible' : ''}`}
+        >
+          {nextButtonText}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default SentimentSliderSpectacular;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './SentimentSlider';
 export { default } from './SentimentSlider';
+export { SentimentSliderSpectacular } from "./SentimentSliderSpectacular";


### PR DESCRIPTION
## Summary
- duplicate component as `SentimentSliderSpectacular`
- add animated gradient background logic and layered ripple effect
- style spectacular variant with bigger ripples and responsive rules
- export new component
- document spectacular usage in README and docs
- test `onConfirm` for the spectacular variant

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c143a72c833187ce83718c65c58e