### PR TITLE
🧹 remove unused refs in SentimentSliderSpectacular

### DIFF
--- a/dist/SentimentSliderSpectacular.js
+++ b/dist/SentimentSliderSpectacular.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './SentimentSliderSpectacular.css';
 /**
  * SentimentSlider Component
@@ -13,8 +13,6 @@ export function SentimentSliderSpectacular(_a) {
     var _h = useState(false), showRipple = _h[0], setShowRipple = _h[1];
     var _j = useState(50), ripplePosition = _j[0], setRipplePosition = _j[1];
     var _k = useState(false), showConfirmButton = _k[0], setShowConfirmButton = _k[1];
-    var sliderRef = useRef(null);
-    var containerRef = useRef(null);
     // Update slider value if initialValue prop changes
     useEffect(function () {
         setSliderValue(initialValue);
@@ -110,13 +108,13 @@ export function SentimentSliderSpectacular(_a) {
     };
     var background = getBackground(sliderValue);
     var sentimentText = getSentimentText(sliderValue);
-    return (React.createElement("div", { className: "sentiment-slider-container ".concat(className), style: { background: background }, ref: containerRef },
+    return (React.createElement("div", { className: "sentiment-slider-container ".concat(className), style: { background: background } },
         React.createElement("div", { className: "sentiment-content" },
             React.createElement("h2", { className: "sentiment-question" }, questionText),
             React.createElement("div", { className: "slider-container" },
                 React.createElement("div", { className: "sentiment-text" }, sentimentText),
                 React.createElement("div", { className: "slider-wrapper" },
-                    React.createElement("input", { ref: sliderRef, type: "range", min: "0", max: "100", value: sliderValue, onChange: handleSliderChange, onMouseDown: handleSlideStart, onTouchStart: handleSlideStart, onMouseUp: handleSlideEnd, onTouchEnd: handleSlideEnd, className: "sentiment-slider" }),
+                    React.createElement("input", { type: "range", min: "0", max: "100", value: sliderValue, onChange: handleSliderChange, onMouseDown: handleSlideStart, onTouchStart: handleSlideStart, onMouseUp: handleSlideEnd, onTouchEnd: handleSlideEnd, className: "sentiment-slider" }),
                     showRipple && (React.createElement(React.Fragment, null,
                         React.createElement("div", { className: "ripple ripple-primary", style: { left: "".concat(ripplePosition, "%") } }),
                         React.createElement("div", { className: "ripple ripple-secondary", style: { left: "".concat(ripplePosition, "%") } })))),

--- a/src/SentimentSliderSpectacular.tsx
+++ b/src/SentimentSliderSpectacular.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './SentimentSliderSpectacular.css';
 
 /**
@@ -52,8 +52,6 @@ export function SentimentSliderSpectacular({
   const [showRipple, setShowRipple] = useState(false);
   const [ripplePosition, setRipplePosition] = useState(50);
   const [showConfirmButton, setShowConfirmButton] = useState(false);
-  const sliderRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   // Update slider value if initialValue prop changes
   useEffect(() => {
@@ -163,7 +161,6 @@ export function SentimentSliderSpectacular({
     <div 
       className={`sentiment-slider-container ${className}`} 
       style={{ background }}
-      ref={containerRef}
     >
       <div className="sentiment-content">
         <h2 className="sentiment-question">{questionText}</h2>
@@ -173,7 +170,6 @@ export function SentimentSliderSpectacular({
           
           <div className="slider-wrapper">
             <input
-              ref={sliderRef}
               type="range"
               min="0"
               max="100"


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of unused React refs (`sliderRef` and `containerRef`) in the `SentimentSliderSpectacular` component.

💡 **Why:** Removing dead code improves the maintainability and readability of the codebase, making it easier for future developers to understand what's actually necessary for the component's functionality.

✅ **Verification:**
- Confirmed that the refs were only used for assignment in the JSX and were not accessed in any `useEffect` hooks or event handlers.
- Successfully ran `npm run build` to ensure the project still compiles correctly.
- Verified that the transpiled `dist/SentimentSliderSpectacular.js` no longer contains the unused refs.

✨ **Result:** A cleaner and more concise component implementation.

---
*PR created automatically by Jules for task [16815374717090912780](https://jules.google.com/task/16815374717090912780) started by @Billsobey*