### PR TITLE
⚡ Optimize global scroll event listeners for better performance

### DIFF
--- a/dist/SentimentSlider.js
+++ b/dist/SentimentSlider.js
@@ -81,20 +81,21 @@ export function SentimentSlider(_a) {
                 e.preventDefault();
             }
         };
-        document.addEventListener('touchmove', preventTouchScroll, { passive: false });
-        document.addEventListener('wheel', preventWheelScroll, { passive: false });
-        document.addEventListener('touchstart', preventElasticScroll, { passive: false });
-        // Use no-scroll class to prevent scrolling
         if (isSliding) {
+            document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+            document.addEventListener('wheel', preventWheelScroll, { passive: false });
+            document.addEventListener('touchstart', preventElasticScroll, { passive: false });
             document.body.classList.add('no-scroll');
         }
         else {
             document.body.classList.remove('no-scroll');
         }
         return function () {
-            document.removeEventListener('touchmove', preventTouchScroll);
-            document.removeEventListener('wheel', preventWheelScroll);
-            document.removeEventListener('touchstart', preventElasticScroll);
+            if (isSliding) {
+                document.removeEventListener('touchmove', preventTouchScroll);
+                document.removeEventListener('wheel', preventWheelScroll);
+                document.removeEventListener('touchstart', preventElasticScroll);
+            }
             document.body.classList.remove('no-scroll');
         };
     }, [isSliding]);

--- a/dist/SentimentSliderSpectacular.js
+++ b/dist/SentimentSliderSpectacular.js
@@ -60,20 +60,21 @@ export function SentimentSliderSpectacular(_a) {
                 e.preventDefault();
             }
         };
-        document.addEventListener('touchmove', preventTouchScroll, { passive: false });
-        document.addEventListener('wheel', preventWheelScroll, { passive: false });
-        document.addEventListener('touchstart', preventElasticScroll, { passive: false });
-        // Use no-scroll class to prevent scrolling
         if (isSliding) {
+            document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+            document.addEventListener('wheel', preventWheelScroll, { passive: false });
+            document.addEventListener('touchstart', preventElasticScroll, { passive: false });
             document.body.classList.add('no-scroll');
         }
         else {
             document.body.classList.remove('no-scroll');
         }
         return function () {
-            document.removeEventListener('touchmove', preventTouchScroll);
-            document.removeEventListener('wheel', preventWheelScroll);
-            document.removeEventListener('touchstart', preventElasticScroll);
+            if (isSliding) {
+                document.removeEventListener('touchmove', preventTouchScroll);
+                document.removeEventListener('wheel', preventWheelScroll);
+                document.removeEventListener('touchstart', preventElasticScroll);
+            }
             document.body.classList.remove('no-scroll');
         };
     }, [isSliding]);

--- a/src/SentimentSlider.tsx
+++ b/src/SentimentSlider.tsx
@@ -125,21 +125,21 @@ export function SentimentSlider({
       }
     };
 
-    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
-    document.addEventListener('wheel', preventWheelScroll, { passive: false });
-    document.addEventListener('touchstart', preventElasticScroll, { passive: false });
-
-    // Use no-scroll class to prevent scrolling
     if (isSliding) {
+      document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+      document.addEventListener('wheel', preventWheelScroll, { passive: false });
+      document.addEventListener('touchstart', preventElasticScroll, { passive: false });
       document.body.classList.add('no-scroll');
     } else {
       document.body.classList.remove('no-scroll');
     }
 
     return () => {
-      document.removeEventListener('touchmove', preventTouchScroll);
-      document.removeEventListener('wheel', preventWheelScroll);
-      document.removeEventListener('touchstart', preventElasticScroll);
+      if (isSliding) {
+        document.removeEventListener('touchmove', preventTouchScroll);
+        document.removeEventListener('wheel', preventWheelScroll);
+        document.removeEventListener('touchstart', preventElasticScroll);
+      }
       document.body.classList.remove('no-scroll');
     };
   }, [isSliding]);

--- a/src/SentimentSliderSpectacular.tsx
+++ b/src/SentimentSliderSpectacular.tsx
@@ -100,21 +100,21 @@ export function SentimentSliderSpectacular({
       }
     };
 
-    document.addEventListener('touchmove', preventTouchScroll, { passive: false });
-    document.addEventListener('wheel', preventWheelScroll, { passive: false });
-    document.addEventListener('touchstart', preventElasticScroll, { passive: false });
-
-    // Use no-scroll class to prevent scrolling
     if (isSliding) {
+      document.addEventListener('touchmove', preventTouchScroll, { passive: false });
+      document.addEventListener('wheel', preventWheelScroll, { passive: false });
+      document.addEventListener('touchstart', preventElasticScroll, { passive: false });
       document.body.classList.add('no-scroll');
     } else {
       document.body.classList.remove('no-scroll');
     }
 
     return () => {
-      document.removeEventListener('touchmove', preventTouchScroll);
-      document.removeEventListener('wheel', preventWheelScroll);
-      document.removeEventListener('touchstart', preventElasticScroll);
+      if (isSliding) {
+        document.removeEventListener('touchmove', preventTouchScroll);
+        document.removeEventListener('wheel', preventWheelScroll);
+        document.removeEventListener('touchstart', preventElasticScroll);
+      }
       document.body.classList.remove('no-scroll');
     };
   }, [isSliding]);


### PR DESCRIPTION
💡 **What:** Optimized the `useEffect` hook in both `SentimentSlider` and `SentimentSliderSpectacular` components to conditionally add global, non-passive event listeners (`touchmove`, `wheel`, `touchstart`) only when the user is actively interacting with the slider (`isSliding` is true).

🎯 **Why:** Global, non-passive event listeners can block the main thread and prevent the browser from using compositor-thread scrolling, leading to "scroll jank" even when the slider component is not being used. By only attaching these listeners during an active slide, we ensure that normal page scrolling remains smooth and efficient.

📊 **Measured Improvement:** While direct scroll jank measurement is impractical in this environment, this change follows standard web performance best practices. By removing non-passive listeners from the document during idle states, the browser's compositor can handle scroll events directly without waiting for the main thread, which is a significant and measurable architectural improvement for web responsiveness.

---
*PR created automatically by Jules for task [13736644541364180781](https://jules.google.com/task/13736644541364180781) started by @Billsobey*